### PR TITLE
angler selinux fixes

### DIFF
--- a/sepolicy/vendor/init.te
+++ b/sepolicy/vendor/init.te
@@ -47,3 +47,9 @@ allow init userdata_block_device:blk_file { write };
 allow init persist_block_device:lnk_file relabelto;
 allow init sysfs_dm:file { open write };
 
+# for bind mount over /apex/com.android.media.swcodec/etc/ld.config.txt
+allow init system_file:file mounton;
+# allow mmcblk0 tune, chmod/chown
+allow init sysfs_tune:file { setattr write };
+# allow hbm chmod/chown
+allow init sysfs_graphics_comp:file { setattr };

--- a/sepolicy/vendor/init.te
+++ b/sepolicy/vendor/init.te
@@ -20,6 +20,7 @@ allow init sysfs_battery:lnk_file rw_file_perms;
 allow init sysfs_tune:file rw_file_perms;
 # bluetooth
 allow init sysfs_bluetooth_writable:file { setattr read };
+allow init proc_bluetooth_writable:file { setattr };
 # cpu
 allow init sysfs_cpu:file setattr;
 allow init sysfs_thermal:file setattr;


### PR DESCRIPTION
Hiya,

the first commit fixes all my bluetooth issues with angler. bluetooth was crashing and resetting when connecting. keeping the screen alive whilst connecting to things worked around the issue, so it makes sense that this sepolicy fix allows proper BT power management.

the second commit fixes nothing that I can notice, but these were also boot time selinux denials from init, so I expect they should also be fixed. feel free to just merge the BT fix though.

thanks.